### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   scripts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FitimZulfiju/Ai-CV-application-generator/security/code-scanning/7](https://github.com/FitimZulfiju/Ai-CV-application-generator/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/validate.yml` at the workflow root level so it applies to all jobs (currently just `scripts`). The least-privilege setting for this workflow is:

- `contents: read`

Place it after the `on:` trigger block and before `jobs:`. This preserves existing behavior (checkout + lint) while ensuring `GITHUB_TOKEN` is constrained.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
